### PR TITLE
Set up ajv-errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,7 @@ module.exports = {
     ecmaVersion: 12,
   },
   plugins: ["@typescript-eslint"],
-  rules: {},
+  rules: {
+    "@typescript-eslint/no-non-null-assertion": "off",
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "chai": "^4.3.4",
         "eslint": "^7.28.0",
         "eslint-config-prettier": "^8.3.0",
+        "fast-check": "^2.16.0",
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
         "mocha": "^8.4.0",
@@ -1838,6 +1839,22 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-check": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.16.0.tgz",
+      "integrity": "sha512-r1uoJQoLzKUgfAeGzSZ/7dGyvSLG3OGjmWIKZRJpKtY/791di7n/x389F0Bei3Ry8126Z6MKp78Cbt4+9LUp1g==",
+      "dev": true,
+      "dependencies": {
+        "pure-rand": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3588,6 +3605,16 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-4.2.1.tgz",
+      "integrity": "sha512-ESI2eqHP9JlrnTb7H7fgczRUWB6VxMMJ2m9870WCIBhYkBzSGd6gml6WhQVXHK+ZM8k70TqsyI28ixaLPaNz5g==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
       }
     },
     "node_modules/queue-microtask": {
@@ -5839,6 +5866,15 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "fast-check": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.16.0.tgz",
+      "integrity": "sha512-r1uoJQoLzKUgfAeGzSZ/7dGyvSLG3OGjmWIKZRJpKtY/791di7n/x389F0Bei3Ry8126Z6MKp78Cbt4+9LUp1g==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^4.1.1"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7134,6 +7170,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "pure-rand": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-4.2.1.tgz",
+      "integrity": "sha512-ESI2eqHP9JlrnTb7H7fgczRUWB6VxMMJ2m9870WCIBhYkBzSGd6gml6WhQVXHK+ZM8k70TqsyI28ixaLPaNz5g==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.6.0",
+        "ajv-errors": "^3.0.0",
         "globby": "^11.0.3",
         "js-yaml": "^4.1.0"
       },
@@ -941,6 +942,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -5149,6 +5158,12 @@
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "^4.3.4",
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
+    "fast-check": "^2.16.0",
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "mocha": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/wei2912/planwithus-lib#readme",
   "dependencies": {
     "ajv": "^8.6.0",
+    "ajv-errors": "^3.0.0",
     "globby": "^11.0.3",
     "js-yaml": "^4.1.0"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,14 @@
+import Ajv from "ajv";
+import ajvErrors from "ajv-errors";
 import { should } from "chai";
 
 import { initVerifiers } from "./";
+
+const ajv = new Ajv({
+  allErrors: true, // necessary for ajv-errors
+  allowUnionTypes: true,
+});
+ajvErrors(ajv);
 
 should();
 
@@ -15,3 +23,5 @@ describe("initVerifiers", () => {
     verifiers.should.have.property("minor");
   });
 });
+
+export { ajv };

--- a/src/matchRule/pattern.test.ts
+++ b/src/matchRule/pattern.test.ts
@@ -1,0 +1,64 @@
+import { should } from "chai";
+import { assert, constantFrom, property, stringOf, tuple } from "fast-check";
+
+import { ajv } from "../index.test";
+import { patternSchema } from "./pattern";
+
+const ajvValidate = ajv.compile(patternSchema);
+
+const UPPERCASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const DIGITS = "0123456789".split("");
+
+const modulePrefix = stringOf(constantFrom(...UPPERCASE_LETTERS), {
+  minLength: 2,
+  maxLength: 3,
+});
+const moduleNumber = stringOf(constantFrom("x", "*", ...DIGITS), {
+  minLength: 1,
+  maxLength: 4,
+});
+const moduleSuffix = stringOf(constantFrom(...UPPERCASE_LETTERS), {
+  minLength: 0,
+  maxLength: 1,
+});
+const pattern = tuple(modulePrefix, moduleNumber, moduleSuffix).map(
+  (t: [string, string, string]) => t.join("")
+);
+
+should();
+
+const isValidPattern = (patternStr: string) =>
+  ajvValidate(patternStr).should.be.true;
+
+const isInvalidPattern = (patternStr: string) => {
+  ajvValidate(patternStr).should.be.false;
+  ajvValidate.should.have.property("errors");
+
+  const errors = ajvValidate.errors!;
+  errors.should.be.an("array");
+  errors.should.have.lengthOf.above(0);
+
+  const error = errors[0];
+  error.should.have.property("message");
+  error.message!.should.equal(
+    "pattern should be a non-empty string composed of A-Z, 0-9, x or *"
+  );
+};
+
+describe("patternSchema", () => {
+  it("should validate valid module code", () =>
+    ["ACC1002", "GER1000", "IS1103", "CS1231S", "MA1102R", "MA2101S"].forEach(
+      isValidPattern
+    ));
+  it("should validate wildcard", () => isValidPattern("*"));
+  it("should validate non-empty pattern composed of A-Z, 0-9, x or *", () =>
+    assert(property(pattern, (patternStr) => ajvValidate(patternStr))));
+
+  it("should not validate empty pattern", () => isInvalidPattern(""));
+  it("should not validate pattern with invalid characters", () =>
+    ["AB123a", "Ac123a", "AB123^S", "AB1*3^S", "$A1*3^S", "/A1x33S"].forEach(
+      isInvalidPattern
+    ));
+});
+
+export { pattern };

--- a/src/matchRule/pattern.ts
+++ b/src/matchRule/pattern.ts
@@ -4,7 +4,9 @@ type Pattern = string;
 
 const patternSchema: JSONSchemaType<Pattern> = {
   type: "string",
-  pattern: "^[A-Z0-9x*]*$",
+  pattern: "^[A-Z0-9x*]+$",
+  errorMessage:
+    "pattern should be a non-empty string composed of A-Z, 0-9, x or *",
 };
 
 export type { Pattern };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,4 +1,5 @@
 import Ajv from "ajv";
+import ajvErrors from "ajv-errors";
 import yaml from "js-yaml";
 
 import type { Block } from "../block";
@@ -7,9 +8,11 @@ import { matchRuleSchema } from "../matchRule";
 import { satisfyRuleSchema } from "../satisfyRule";
 
 const ajv = new Ajv({
+  allErrors: true, // necessary for ajv-errors
   allowUnionTypes: true,
   schemas: [matchRuleSchema, satisfyRuleSchema],
 });
+ajvErrors(ajv);
 const ajvValidate = ajv.compile(blockSchema);
 
 const parse = (block: unknown): Block => {


### PR DESCRIPTION
This PR sets up [ajv-errors](https://github.com/ajv-validator/ajv-errors) which can provide custom human-friendly error messages. This is still a WIP and should be merged in only after a test suite has been built.