### PR TITLE
Implement matchers

### DIFF
--- a/src/block/matchers.ts
+++ b/src/block/matchers.ts
@@ -1,0 +1,29 @@
+import { Directory } from "../directory";
+import { matchRuleMatcher } from "../matchRule/matchers";
+import type { MatcherBranch } from "../matcher/types";
+import type { Some } from "../some/types";
+import type { BlockId } from "./blockId/types";
+import type { Block } from "./types";
+
+const blockAssignMatcher = (
+  dir: Directory,
+  assign: Some<BlockId>
+): MatcherBranch => ({
+  matchers: Array.isArray(assign)
+    ? assign.map((blockId) => blockMatcher(dir, dir.find(blockId)))
+    : [blockMatcher(dir, dir.find(assign))],
+  constraint: () => true,
+});
+
+const blockMatcher = (
+  dir: Directory,
+  { assign, match }: Block
+): MatcherBranch => ({
+  matchers: [
+    ...(typeof assign === "undefined" ? [] : [blockAssignMatcher(dir, assign)]),
+    ...(typeof match === "undefined" ? [] : [matchRuleMatcher(match)]),
+  ],
+  constraint: () => true,
+});
+
+export { blockMatcher };

--- a/src/block/matchers.ts
+++ b/src/block/matchers.ts
@@ -3,27 +3,38 @@ import { matchRuleMatcher } from "../matchRule/matchers";
 import type { MatcherBranch } from "../matcher/types";
 import type { Some } from "../some/types";
 import type { BlockId } from "./blockId/types";
-import type { Block } from "./types";
 
 const blockAssignMatcher = (
   dir: Directory,
+  prefix: string,
   assign: Some<BlockId>
 ): MatcherBranch => ({
+  type: "assign",
+  rule: assign,
   matchers: Array.isArray(assign)
-    ? assign.map((blockId) => blockMatcher(dir, dir.find(blockId)))
-    : [blockMatcher(dir, dir.find(assign))],
+    ? assign.map((blockId) => blockMatcher(dir, prefix, blockId))
+    : [blockMatcher(dir, prefix, assign)],
   constraint: () => true,
 });
 
 const blockMatcher = (
   dir: Directory,
-  { assign, match }: Block
-): MatcherBranch => ({
-  matchers: [
-    ...(typeof assign === "undefined" ? [] : [blockAssignMatcher(dir, assign)]),
-    ...(typeof match === "undefined" ? [] : [matchRuleMatcher(match)]),
-  ],
-  constraint: () => true,
-});
+  prefix: string,
+  blockId: BlockId
+): MatcherBranch => {
+  const [newPrefix, block] = dir.find(prefix, blockId);
+  const { assign, match } = block;
+  return {
+    type: "block",
+    rule: { prefix: newPrefix, block },
+    matchers: [
+      ...(typeof assign === "undefined"
+        ? []
+        : [blockAssignMatcher(dir, newPrefix, assign)]),
+      ...(typeof match === "undefined" ? [] : [matchRuleMatcher(match)]),
+    ],
+    constraint: () => true,
+  };
+};
 
 export { blockMatcher };

--- a/src/block/satisfiers.test.ts
+++ b/src/block/satisfiers.test.ts
@@ -1,0 +1,28 @@
+import { initDirectories } from "../";
+import { blockSatisfier } from "../block/satisfiers";
+import { evaluateSatisfier } from "../satisfier";
+import type { Module } from "../module/types";
+
+describe("blockSatisfier", () => {
+  it("idk if this works", async () => {
+    const { primary } = await initDirectories();
+    console.log(Object.keys(primary.blocks));
+    const satisfier = blockSatisfier(primary, "", "cs-hons-2020");
+    const modules = [
+      ["CS1101S", 4],
+      ["CS1231S", 4],
+      ["CS2030S", 4],
+      ["CS2040S", 4],
+      ["CS2100", 4],
+      ["CS2103T", 4],
+      ["DSA1101", 4],
+      ["MA1101R", 4],
+      ["MA2002", 4],
+      ["CS2106", 4],
+      ["CS3230", 4],
+      ["CS3244", 4],
+      ["PC1231", 4],
+    ] as Module[];
+    console.log(JSON.stringify(evaluateSatisfier(modules, satisfier), null, 2));
+  });
+});

--- a/src/block/satisfiers.ts
+++ b/src/block/satisfiers.ts
@@ -1,0 +1,31 @@
+import { Directory } from "../directory";
+import { evaluateMatcher } from "../matcher";
+import type {
+  Satisfier,
+  SatisfierBranch,
+  SatisfierLeaf,
+} from "../satisfier/types";
+import { satisfyRuleSatisfier } from "../satisfyRule/satisfiers";
+import { blockMatcher } from "./matchers";
+import type { Block } from "./types";
+
+const blockSatisfier = (dir: Directory, block: Block): SatisfierBranch => {
+  const { satisfy, info } = block;
+  const infoSatisfier: SatisfierLeaf = {
+    constraint: () => true,
+    infos: typeof info === "undefined" ? [] : [info],
+    messages: [],
+  };
+  return {
+    filter: (assigned) => {
+      const { matched } = evaluateMatcher(assigned, blockMatcher(dir, block));
+      return matched;
+    },
+    satisfiers: ([infoSatisfier] as Satisfier[]).concat(
+      typeof satisfy === "undefined" ? [] : [satisfyRuleSatisfier(dir, satisfy)]
+    ),
+    constraint: (satisfieds) => satisfieds.every((bool) => bool),
+  };
+};
+
+export { blockSatisfier };

--- a/src/block/satisfiers.ts
+++ b/src/block/satisfiers.ts
@@ -1,29 +1,53 @@
 import { Directory } from "../directory";
 import { evaluateMatcher } from "../matcher";
-import type {
-  Satisfier,
-  SatisfierBranch,
-  SatisfierLeaf,
-} from "../satisfier/types";
+import type { SatisfierBranch, SatisfierLeaf } from "../satisfier/types";
 import { satisfyRuleSatisfier } from "../satisfyRule/satisfiers";
 import { blockMatcher } from "./matchers";
-import type { Block } from "./types";
+import type { BlockId } from "./blockId/types";
 
-const blockSatisfier = (dir: Directory, block: Block): SatisfierBranch => {
-  const { satisfy, info } = block;
+const blockSatisfier = (
+  dir: Directory,
+  prefix: string,
+  blockId: BlockId
+): SatisfierBranch => {
+  const [newPrefix, block] = dir.find(prefix, blockId);
+  const { assign, satisfy, info } = block;
+
   const infoSatisfier: SatisfierLeaf = {
+    type: "info",
+    rule: null,
     constraint: () => true,
-    infos: typeof info === "undefined" ? [] : [info],
-    messages: [],
+    info,
   };
+  const assignBlockIds: BlockId[] =
+    typeof assign === "undefined"
+      ? []
+      : Array.isArray(assign)
+      ? assign
+      : [assign];
+  const assignSatisfier = {
+    ...satisfyRuleSatisfier(dir, newPrefix, assignBlockIds),
+    type: "assign",
+    rule: assign,
+  };
+
   return {
+    type: "block",
+    rule: { prefix: newPrefix, block },
     filter: (assigned) => {
-      const { matched } = evaluateMatcher(assigned, blockMatcher(dir, block));
+      const { matched } = evaluateMatcher(
+        assigned,
+        blockMatcher(dir, prefix, blockId)
+      );
       return matched;
     },
-    satisfiers: ([infoSatisfier] as Satisfier[]).concat(
-      typeof satisfy === "undefined" ? [] : [satisfyRuleSatisfier(dir, satisfy)]
-    ),
+    satisfiers: [
+      ...(typeof info === "undefined" ? [] : [infoSatisfier]),
+      ...(typeof assign === "undefined" ? [] : [assignSatisfier]),
+      ...(typeof satisfy === "undefined"
+        ? []
+        : [satisfyRuleSatisfier(dir, newPrefix, satisfy)]),
+    ],
     constraint: (satisfieds) => satisfieds.every((bool) => bool),
   };
 };

--- a/src/directory/index.ts
+++ b/src/directory/index.ts
@@ -1,5 +1,6 @@
 import { decomposeBlock } from "../block";
 import type { Block } from "../block/types";
+import type { BlockId } from "../block/blockId/types";
 
 class Directory {
   blocks: Record<string, Block>;
@@ -24,11 +25,19 @@ class Directory {
     });
   }
 
-  find(prefix: string): Block {
-    if (prefix in Object.keys(this.blocks)) {
-      throw new Error(`block '${prefix}' does not exist`);
+  find(prefix: string, id: BlockId): [BlockId, Block] {
+    const prefixedId = prefix === "" ? id : [prefix, id].join("/");
+    if (Object.keys(this.blocks).includes(id)) {
+      return [id, this.blocks[id]];
+    } else if (Object.keys(this.blocks).includes(prefixedId)) {
+      return [prefixedId, this.blocks[prefixedId]];
+    } else {
+      throw new Error(
+        id !== prefixedId
+          ? `block '${id}' or '${prefixedId}' does not exist`
+          : `block '${id}' does not exist`
+      );
     }
-    return this.blocks[prefix];
   }
 }
 

--- a/src/matchRule/index.ts
+++ b/src/matchRule/index.ts
@@ -1,0 +1,13 @@
+import { evaluateMatcher } from "../matcher";
+import type { MatcherResult } from "../matcher/types";
+import type { Module } from "../module/types";
+import type { Some } from "../some/types";
+import { matchRuleMatcher } from "./matchers";
+import type { MatchRule } from "./types";
+
+const performMatch = (
+  match: Some<MatchRule>,
+  modules: Module[]
+): MatcherResult => evaluateMatcher(modules, matchRuleMatcher(match));
+
+export { performMatch };

--- a/src/matchRule/matchers.test.ts
+++ b/src/matchRule/matchers.test.ts
@@ -1,25 +1,26 @@
 import chai from "chai";
 
 import { evaluateMatcher } from "../matcher";
+import type { Module } from "../module/types";
 import { matchRuleMatcher, patternMatchRuleMatcher } from "./matchers";
 
 chai.should();
 
 describe("matchRuleMatcher", () => {
-  const modulesList1 = [
-    "MA1100",
-    "CS1231",
-    "CS1231S",
-    "MA1101R",
-    "MA1513",
-    "MA1102R",
-    "MA1511",
-    "MA1511A",
-    "MA1512",
-    "MA1507",
-    "MA1521",
-    "MA2101",
-    "MA2101S",
+  const modulesList1: Module[] = [
+    ["MA1100", 4],
+    ["CS1231", 4],
+    ["CS1231S", 4],
+    ["MA1101R", 4],
+    ["MA1513", 4],
+    ["MA1102R", 4],
+    ["MA1511", 4],
+    ["MA1511A", 4],
+    ["MA1512", 4],
+    ["MA1507", 4],
+    ["MA1521", 4],
+    ["MA2101", 4],
+    ["MA2101S", 4],
   ];
 
   it("should match only valid modules with pattern match rule", () => {
@@ -29,17 +30,22 @@ describe("matchRuleMatcher", () => {
       info: "swag",
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: ["MA1100", "MA1101R", "MA1102R", "MA1511A"],
+      matched: [
+        ["MA1100", 4],
+        ["MA1101R", 4],
+        ["MA1102R", 4],
+        ["MA1511A", 4],
+      ],
       remaining: [
-        "CS1231",
-        "CS1231S",
-        "MA1513",
-        "MA1511",
-        "MA1512",
-        "MA1507",
-        "MA1521",
-        "MA2101",
-        "MA2101S",
+        ["CS1231", 4],
+        ["CS1231S", 4],
+        ["MA1513", 4],
+        ["MA1511", 4],
+        ["MA1512", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+        ["MA2101", 4],
+        ["MA2101S", 4],
       ],
       infos: ["swag"],
     });
@@ -53,15 +59,22 @@ describe("matchRuleMatcher", () => {
       ],
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: ["MA1513", "MA1511", "MA1511A", "MA1512", "MA1507", "MA1521"],
+      matched: [
+        ["MA1513", 4],
+        ["MA1511", 4],
+        ["MA1511A", 4],
+        ["MA1512", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+      ],
       remaining: [
-        "MA1100",
-        "CS1231",
-        "CS1231S",
-        "MA1101R",
-        "MA1102R",
-        "MA2101",
-        "MA2101S",
+        ["MA1100", 4],
+        ["CS1231", 4],
+        ["CS1231S", 4],
+        ["MA1101R", 4],
+        ["MA1102R", 4],
+        ["MA2101", 4],
+        ["MA2101S", 4],
       ],
       infos: ["hi1"],
     });
@@ -119,18 +132,22 @@ describe("matchRuleMatcher", () => {
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
       matched: [
-        "CS1231",
-        "MA1100",
-        "CS1231S",
-        "MA2101",
-        "MA2101S",
-        "MA1101R",
-        "MA1102R",
-        "MA1511",
-        "MA1512",
-        "MA1511A",
+        ["CS1231", 4],
+        ["MA1100", 4],
+        ["CS1231S", 4],
+        ["MA2101", 4],
+        ["MA2101S", 4],
+        ["MA1101R", 4],
+        ["MA1102R", 4],
+        ["MA1511", 4],
+        ["MA1512", 4],
+        ["MA1511A", 4],
       ],
-      remaining: ["MA1513", "MA1507", "MA1521"],
+      remaining: [
+        ["MA1513", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+      ],
       infos: ["foo", "bar", "swag", "true swag"],
     });
   });

--- a/src/matchRule/matchers.test.ts
+++ b/src/matchRule/matchers.test.ts
@@ -1,0 +1,137 @@
+import chai from "chai";
+
+import { evaluateMatcher } from "../matcher";
+import { matchRuleMatcher, patternMatchRuleMatcher } from "./matchers";
+
+chai.should();
+
+describe("matchRuleMatcher", () => {
+  const modulesList1 = [
+    "MA1100",
+    "CS1231",
+    "CS1231S",
+    "MA1101R",
+    "MA1513",
+    "MA1102R",
+    "MA1511",
+    "MA1511A",
+    "MA1512",
+    "MA1507",
+    "MA1521",
+    "MA2101",
+    "MA2101S",
+  ];
+
+  it("should match only valid modules with pattern match rule", () => {
+    const matcher = patternMatchRuleMatcher({
+      pattern: "MA1xxx*",
+      exclude: "MA15xx",
+      info: "swag",
+    });
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: ["MA1100", "MA1101R", "MA1102R", "MA1511A"],
+      remaining: [
+        "CS1231",
+        "CS1231S",
+        "MA1513",
+        "MA1511",
+        "MA1512",
+        "MA1507",
+        "MA1521",
+        "MA2101",
+        "MA2101S",
+      ],
+      infos: ["swag"],
+    });
+  });
+
+  it("should match only valid modules once if or rule has duplicate rules", () => {
+    const matcher = matchRuleMatcher({
+      or: [
+        { pattern: "MA1xxx*", exclude: "MA11xx*", info: "hi1" },
+        { pattern: "MA1xxx*", exclude: "MA11xx*", info: "hi2" },
+      ],
+    });
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: ["MA1513", "MA1511", "MA1511A", "MA1512", "MA1507", "MA1521"],
+      remaining: [
+        "MA1100",
+        "CS1231",
+        "CS1231S",
+        "MA1101R",
+        "MA1102R",
+        "MA2101",
+        "MA2101S",
+      ],
+      infos: ["hi1"],
+    });
+  });
+
+  it("should match no modules if and rule has duplicate rules", () => {
+    const matcher = matchRuleMatcher({
+      and: [
+        { pattern: "MA1xxx*", exclude: "MA11xx*", info: "hi1" },
+        { pattern: "MA1xxx*", exclude: "MA11xx*", info: "hi2" },
+      ],
+    });
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: [],
+      remaining: modulesList1,
+      infos: [],
+    });
+  });
+
+  it("should match only valid modules with recursive match rules", () => {
+    const matcher = matchRuleMatcher({
+      or: [
+        { pattern: "CS1231", info: "foo" },
+        "MA1100",
+        {
+          and: [
+            { pattern: "CS1231*", info: "bar" },
+            { pattern: "MA2101*", info: "swag" },
+          ],
+        },
+        {
+          and: [
+            {
+              or: [{ and: ["MA1511", "MA1512"] }, { pattern: "ACC*" }],
+            },
+            {
+              and: [
+                { pattern: "CS1231S", info: "swaggy" },
+                { pattern: "MA1101R", info: "thomas" },
+                "MA1102R",
+              ],
+            },
+            "MA1xxx*",
+          ],
+        },
+        {
+          and: [
+            { pattern: "MA11xx*", info: "true swag" },
+            "MA1511",
+            "MA1512",
+            { or: ["MA6220", "MA1511A"] },
+          ],
+        },
+      ],
+    });
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: [
+        "CS1231",
+        "MA1100",
+        "CS1231S",
+        "MA2101",
+        "MA2101S",
+        "MA1101R",
+        "MA1102R",
+        "MA1511",
+        "MA1512",
+        "MA1511A",
+      ],
+      remaining: ["MA1513", "MA1507", "MA1521"],
+      infos: ["foo", "bar", "swag", "true swag"],
+    });
+  });
+});

--- a/src/matchRule/matchers.test.ts
+++ b/src/matchRule/matchers.test.ts
@@ -30,6 +30,7 @@ describe("matchRuleMatcher", () => {
       info: "swag",
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "patternMatchRule",
       matched: [
         ["MA1100", 4],
         ["MA1101R", 4],
@@ -47,7 +48,8 @@ describe("matchRuleMatcher", () => {
         ["MA2101", 4],
         ["MA2101S", 4],
       ],
-      infos: ["swag"],
+      results: [],
+      info: "swag",
     });
   });
 
@@ -59,6 +61,7 @@ describe("matchRuleMatcher", () => {
       ],
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "orMatchRule",
       matched: [
         ["MA1513", 4],
         ["MA1511", 4],
@@ -76,7 +79,44 @@ describe("matchRuleMatcher", () => {
         ["MA2101", 4],
         ["MA2101S", 4],
       ],
-      infos: ["hi1"],
+      results: [
+        {
+          type: "patternMatchRule",
+          matched: [
+            ["MA1513", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+          ],
+          remaining: [
+            ["MA1100", 4],
+            ["CS1231", 4],
+            ["CS1231S", 4],
+            ["MA1101R", 4],
+            ["MA1102R", 4],
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          results: [],
+          info: "hi1",
+        },
+        {
+          type: "patternMatchRule",
+          matched: [],
+          remaining: [
+            ["MA1100", 4],
+            ["CS1231", 4],
+            ["CS1231S", 4],
+            ["MA1101R", 4],
+            ["MA1102R", 4],
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          results: [],
+        },
+      ],
     });
   });
 
@@ -88,9 +128,47 @@ describe("matchRuleMatcher", () => {
       ],
     });
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "andMatchRule",
       matched: [],
       remaining: modulesList1,
-      infos: [],
+      results: [
+        {
+          type: "patternMatchRule",
+          matched: [
+            ["MA1513", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+          ],
+          remaining: [
+            ["MA1100", 4],
+            ["CS1231", 4],
+            ["CS1231S", 4],
+            ["MA1101R", 4],
+            ["MA1102R", 4],
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          results: [],
+          info: "hi1",
+        },
+        {
+          type: "patternMatchRule",
+          matched: [],
+          remaining: [
+            ["MA1100", 4],
+            ["CS1231", 4],
+            ["CS1231S", 4],
+            ["MA1101R", 4],
+            ["MA1102R", 4],
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          results: [],
+        },
+      ],
     });
   });
 
@@ -106,49 +184,177 @@ describe("matchRuleMatcher", () => {
           ],
         },
         {
-          and: [
-            {
-              or: [{ and: ["MA1511", "MA1512"] }, { pattern: "ACC*" }],
-            },
-            {
-              and: [
-                { pattern: "CS1231S", info: "swaggy" },
-                { pattern: "MA1101R", info: "thomas" },
-                "MA1102R",
-              ],
-            },
-            "MA1xxx*",
-          ],
-        },
-        {
-          and: [
-            { pattern: "MA11xx*", info: "true swag" },
-            "MA1511",
-            "MA1512",
-            { or: ["MA6220", "MA1511A"] },
-          ],
+          and: [{ pattern: "CS1231S", info: "swaggy" }, "MA1xxx*"],
         },
       ],
     });
-    evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: [
-        ["CS1231", 4],
+
+    const matcherResult = evaluateMatcher(modulesList1, matcher);
+    matcherResult.should.have.property("type");
+    matcherResult.type.should.equal("orMatchRule");
+    matcherResult.should.have.property("matched");
+    matcherResult.matched.should.eql([
+      ["CS1231", 4],
+      ["MA1100", 4],
+      ["CS1231S", 4],
+      ["MA2101", 4],
+      ["MA2101S", 4],
+    ]);
+    matcherResult.should.have.property("remaining");
+    matcherResult.remaining.should.eql([
+      ["MA1101R", 4],
+      ["MA1513", 4],
+      ["MA1102R", 4],
+      ["MA1511", 4],
+      ["MA1511A", 4],
+      ["MA1512", 4],
+      ["MA1507", 4],
+      ["MA1521", 4],
+    ]);
+
+    matcherResult.should.have.property("results");
+    const results = matcherResult.results;
+    results.should.have.lengthOf(4);
+    results[0].should.eql({
+      type: "patternMatchRule",
+      matched: [["CS1231", 4]],
+      remaining: [
         ["MA1100", 4],
+        ["CS1231S", 4],
+        ["MA1101R", 4],
+        ["MA1513", 4],
+        ["MA1102R", 4],
+        ["MA1511", 4],
+        ["MA1511A", 4],
+        ["MA1512", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+        ["MA2101", 4],
+        ["MA2101S", 4],
+      ],
+      results: [],
+      info: "foo",
+    });
+    results[1].should.eql({
+      type: "pattern",
+      matched: [["MA1100", 4]],
+      remaining: [
+        ["CS1231S", 4],
+        ["MA1101R", 4],
+        ["MA1513", 4],
+        ["MA1102R", 4],
+        ["MA1511", 4],
+        ["MA1511A", 4],
+        ["MA1512", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+        ["MA2101", 4],
+        ["MA2101S", 4],
+      ],
+      results: [],
+    });
+    results[2].should.eql({
+      type: "andMatchRule",
+      matched: [
         ["CS1231S", 4],
         ["MA2101", 4],
         ["MA2101S", 4],
-        ["MA1101R", 4],
-        ["MA1102R", 4],
-        ["MA1511", 4],
-        ["MA1512", 4],
-        ["MA1511A", 4],
       ],
       remaining: [
+        ["MA1101R", 4],
         ["MA1513", 4],
+        ["MA1102R", 4],
+        ["MA1511", 4],
+        ["MA1511A", 4],
+        ["MA1512", 4],
         ["MA1507", 4],
         ["MA1521", 4],
       ],
-      infos: ["foo", "bar", "swag", "true swag"],
+      results: [
+        {
+          type: "patternMatchRule",
+          matched: [["CS1231S", 4]],
+          remaining: [
+            ["MA1101R", 4],
+            ["MA1513", 4],
+            ["MA1102R", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          results: [],
+          info: "bar",
+        },
+        {
+          type: "patternMatchRule",
+          matched: [
+            ["MA2101", 4],
+            ["MA2101S", 4],
+          ],
+          remaining: [
+            ["MA1101R", 4],
+            ["MA1513", 4],
+            ["MA1102R", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+          ],
+          results: [],
+          info: "swag",
+        },
+      ],
+    });
+    results[3].should.eql({
+      type: "andMatchRule",
+      matched: [],
+      remaining: [
+        ["MA1101R", 4],
+        ["MA1513", 4],
+        ["MA1102R", 4],
+        ["MA1511", 4],
+        ["MA1511A", 4],
+        ["MA1512", 4],
+        ["MA1507", 4],
+        ["MA1521", 4],
+      ],
+      results: [
+        {
+          type: "patternMatchRule",
+          matched: [],
+          remaining: [
+            ["MA1101R", 4],
+            ["MA1513", 4],
+            ["MA1102R", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+          ],
+          results: [],
+        },
+        {
+          type: "pattern",
+          matched: [
+            ["MA1101R", 4],
+            ["MA1513", 4],
+            ["MA1102R", 4],
+            ["MA1511", 4],
+            ["MA1511A", 4],
+            ["MA1512", 4],
+            ["MA1507", 4],
+            ["MA1521", 4],
+          ],
+          remaining: [],
+          results: [],
+        },
+      ],
     });
   });
 });

--- a/src/matchRule/matchers.ts
+++ b/src/matchRule/matchers.ts
@@ -8,16 +8,14 @@ import type {
   PatternMatchRule,
 } from "./types";
 
-const patternMatchRuleMatcher = ({
-  pattern,
-  exclude = [],
-  info,
-}: PatternMatchRule): MatcherLeaf => {
+const patternMatchRuleMatcher = (rule: PatternMatchRule): MatcherLeaf => {
+  const { pattern, exclude = [], info } = rule;
   const excludeArray = typeof exclude === "string" ? [exclude] : exclude;
   const excludeRE = patternToRE(...excludeArray);
   const { match } = patternMatcher(pattern);
   return {
     type: "patternMatchRule",
+    rule: { pattern, exclude, info },
     match: (module) => {
       const [moduleStr] = module;
       return match(module) && !excludeRE.test(moduleStr);
@@ -28,12 +26,14 @@ const patternMatchRuleMatcher = ({
 
 const andMatchRuleMatcher = ({ and }: AndMatchRule): MatcherBranch => ({
   type: "andMatchRule",
+  rule: { and },
   matchers: and.map(matchRuleMatcher),
   constraint: (matcheds) => matcheds.every((matched) => matched.length > 0),
 });
 
 const orMatchRuleMatcher = ({ or }: OrMatchRule): MatcherBranch => ({
   type: "orMatchRule",
+  rule: { or },
   matchers: or.map(matchRuleMatcher),
   constraint: (matcheds) => matcheds.some((matched) => matched.length > 0),
 });

--- a/src/matchRule/matchers.ts
+++ b/src/matchRule/matchers.ts
@@ -1,0 +1,59 @@
+import type { Matcher, MatcherBranch, MatcherLeaf } from "../matcher/types";
+import type { Some } from "../some/types";
+import { patternMatcher, patternToRE } from "./pattern/matchers";
+import type {
+  AndMatchRule,
+  MatchRule,
+  OrMatchRule,
+  PatternMatchRule,
+} from "./types";
+
+const patternMatchRuleMatcher = ({
+  pattern,
+  exclude = [],
+  info,
+}: PatternMatchRule): MatcherLeaf => {
+  const excludeArray = typeof exclude === "string" ? [exclude] : exclude;
+  const excludeRE = patternToRE(...excludeArray);
+  const { match } = patternMatcher(pattern);
+  return {
+    match: (module) => {
+      const [moduleStr] = module;
+      return match(module) && !excludeRE.test(moduleStr);
+    },
+    infos: typeof info === "undefined" ? [] : [info],
+  };
+};
+
+const andMatchRuleMatcher = ({ and }: AndMatchRule): MatcherBranch => ({
+  matchers: and.map(matchRuleMatcher),
+  constraint: (matcheds) => matcheds.every((matched) => matched.length > 0),
+});
+
+const orMatchRuleMatcher = ({ or }: OrMatchRule): MatcherBranch => ({
+  matchers: or.map(matchRuleMatcher),
+  constraint: (matcheds) => matcheds.some((matched) => matched.length > 0),
+});
+
+const matchRuleMatcher = (match: Some<MatchRule>): Matcher => {
+  if (Array.isArray(match)) {
+    return matchRuleMatcher({ or: match });
+  } else if (typeof match === "string") {
+    return patternMatcher(match);
+  } else if ("pattern" in match) {
+    return patternMatchRuleMatcher(match);
+  } else if ("and" in match) {
+    return andMatchRuleMatcher(match);
+  } else if ("or" in match) {
+    return orMatchRuleMatcher(match);
+  } else {
+    throw new Error("match rule(s) is (are) not well-defined");
+  }
+};
+
+export {
+  andMatchRuleMatcher,
+  matchRuleMatcher,
+  orMatchRuleMatcher,
+  patternMatchRuleMatcher,
+};

--- a/src/matchRule/matchers.ts
+++ b/src/matchRule/matchers.ts
@@ -17,20 +17,23 @@ const patternMatchRuleMatcher = ({
   const excludeRE = patternToRE(...excludeArray);
   const { match } = patternMatcher(pattern);
   return {
+    type: "patternMatchRule",
     match: (module) => {
       const [moduleStr] = module;
       return match(module) && !excludeRE.test(moduleStr);
     },
-    infos: typeof info === "undefined" ? [] : [info],
+    info,
   };
 };
 
 const andMatchRuleMatcher = ({ and }: AndMatchRule): MatcherBranch => ({
+  type: "andMatchRule",
   matchers: and.map(matchRuleMatcher),
   constraint: (matcheds) => matcheds.every((matched) => matched.length > 0),
 });
 
 const orMatchRuleMatcher = ({ or }: OrMatchRule): MatcherBranch => ({
+  type: "orMatchRule",
   matchers: or.map(matchRuleMatcher),
   constraint: (matcheds) => matcheds.some((matched) => matched.length > 0),
 });

--- a/src/matchRule/pattern/index.test.ts
+++ b/src/matchRule/pattern/index.test.ts
@@ -1,4 +1,5 @@
-import { constantFrom, stringOf, tuple } from "fast-check";
+import type { Arbitrary } from "fast-check";
+import { constant, constantFrom, set, stringOf, tuple } from "fast-check";
 
 const UPPERCASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 const DIGITS = "0123456789".split("");
@@ -20,4 +21,29 @@ const pattern = tuple(modulePrefix, moduleNumber, moduleSuffix).map((t) =>
   t.join("")
 );
 
-export { pattern };
+const replaceCharWithArb = (char: string): Arbitrary<string> => {
+  if (char.match(/^[0-9A-Z]$/)) {
+    return constant(char);
+  } else if (char === "x") {
+    return constantFrom(...DIGITS);
+  } else if (char === "*") {
+    return stringOf(constantFrom(...UPPERCASE_LETTERS, ...DIGITS), {
+      minLength: 0,
+      maxLength: 8,
+    });
+  } else {
+    throw new Error("char is not a valid pattern character");
+  }
+};
+
+const patternExample = (patternStr: string): Arbitrary<string> =>
+  patternStr
+    .split("")
+    .map(replaceCharWithArb)
+    .reduce((acc, arb) => tuple(acc, arb).map(([x, y]) => x + y));
+
+const patternExampleList = pattern.chain((patternStr) =>
+  tuple(constant(patternStr), set(patternExample(patternStr), { minLength: 1 }))
+);
+
+export { pattern, patternExampleList };

--- a/src/matchRule/pattern/matchers.test.ts
+++ b/src/matchRule/pattern/matchers.test.ts
@@ -3,6 +3,7 @@ import { array, assert, property, sample } from "fast-check";
 import addContext from "mochawesome/addContext";
 
 import { evaluateMatcher } from "../../matcher";
+import type { Module } from "../../module/types";
 import { pattern, patternExampleList } from "./index.test";
 import { patternToRE, patternMatcher } from "./matchers";
 
@@ -67,14 +68,14 @@ describe("patternToRE", () => {
 });
 
 describe("patternMatcher", () => {
-  const modulesList1 = [
-    "CS2100",
-    "GER1000",
-    "CS2040S",
-    "ST2131",
-    "MA1521",
-    "CS1231",
-    "CS2030",
+  const modulesList1: Module[] = [
+    ["CS2100", 4],
+    ["GER1000", 4],
+    ["CS2040S", 4],
+    ["ST2131", 4],
+    ["MA1521", 4],
+    ["CS1231", 4],
+    ["CS2030", 4],
   ];
 
   it("should match all modules with *", () => {
@@ -89,8 +90,17 @@ describe("patternMatcher", () => {
   it("should match only valid modules with pattern containing *", () => {
     const matcher = patternMatcher("CS2*");
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: ["CS2100", "CS2040S", "CS2030"],
-      remaining: ["GER1000", "ST2131", "MA1521", "CS1231"],
+      matched: [
+        ["CS2100", 4],
+        ["CS2040S", 4],
+        ["CS2030", 4],
+      ],
+      remaining: [
+        ["GER1000", 4],
+        ["ST2131", 4],
+        ["MA1521", 4],
+        ["CS1231", 4],
+      ],
       infos: [],
     });
   });
@@ -98,8 +108,15 @@ describe("patternMatcher", () => {
   it("should match only valid modules with pattern containing x", () => {
     const matcher = patternMatcher("CS20xx");
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: ["CS2030"],
-      remaining: ["CS2100", "GER1000", "CS2040S", "ST2131", "MA1521", "CS1231"],
+      matched: [["CS2030", 4]],
+      remaining: [
+        ["CS2100", 4],
+        ["GER1000", 4],
+        ["CS2040S", 4],
+        ["ST2131", 4],
+        ["MA1521", 4],
+        ["CS1231", 4],
+      ],
       infos: [],
     });
   });
@@ -107,8 +124,17 @@ describe("patternMatcher", () => {
   it("should match only valid modules with pattern containing x and *", () => {
     const matcher = patternMatcher("CS20xx*");
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: ["CS2040S", "CS2030"],
-      remaining: ["CS2100", "GER1000", "ST2131", "MA1521", "CS1231"],
+      matched: [
+        ["CS2040S", 4],
+        ["CS2030", 4],
+      ],
+      remaining: [
+        ["CS2100", 4],
+        ["GER1000", 4],
+        ["ST2131", 4],
+        ["MA1521", 4],
+        ["CS1231", 4],
+      ],
       infos: [],
     });
   });

--- a/src/matchRule/pattern/matchers.test.ts
+++ b/src/matchRule/pattern/matchers.test.ts
@@ -80,15 +80,7 @@ describe("patternMatcher", () => {
   it("should match all modules with *", () => {
     const matcher = patternMatcher("*");
     evaluateMatcher(modulesList1, matcher).should.eql({
-      matched: [
-        "CS2100",
-        "GER1000",
-        "CS2040S",
-        "ST2131",
-        "MA1521",
-        "CS1231",
-        "CS2030",
-      ],
+      matched: modulesList1,
       remaining: [],
       infos: [],
     });

--- a/src/matchRule/pattern/matchers.test.ts
+++ b/src/matchRule/pattern/matchers.test.ts
@@ -1,0 +1,125 @@
+import chai from "chai";
+import { array, assert, property, sample } from "fast-check";
+import addContext from "mochawesome/addContext";
+
+import { evaluateMatcher } from "../../matcher";
+import { pattern, patternExampleList } from "./index.test";
+import { patternToRE, patternMatcher } from "./matchers";
+
+chai.should();
+
+const isInvalidExample = (re: RegExp, example: string) =>
+  re.test.bind(re)(example).should.be.false;
+
+describe("patternToRE", () => {
+  it("should match valid modules with a single pattern", function () {
+    sample(patternExampleList, 10).forEach((sample, i) =>
+      addContext(this, {
+        title: `patternExampleList sample ${i}`,
+        value: sample,
+      })
+    );
+    return assert(
+      property(patternExampleList, ([patternStr, examples]) => {
+        const re = patternToRE(patternStr);
+        return examples.every(re.test.bind(re));
+      })
+    );
+  });
+
+  it("should match valid modules with multiple patterns", function () {
+    const patternExampleListArray = array(patternExampleList, { minLength: 1 });
+    sample(patternExampleListArray, 10).forEach((sample, i) =>
+      addContext(this, {
+        title: `patternExampleListArray sample ${i}`,
+        value: sample,
+      })
+    );
+    return assert(
+      property(patternExampleListArray, (ts) => {
+        const re = patternToRE(...ts.map(([patternStr]) => patternStr));
+        return ts
+          .map(([, examples]) => examples)
+          .flat()
+          .every(re.test.bind(re));
+      })
+    );
+  });
+
+  it("should not match x to non-number", () => {
+    const re = patternToRE("x");
+    ["A", "Z", "c", "#"].forEach((example) => isInvalidExample(re, example));
+  });
+
+  it("should not match * to a substring composed of characters other than A-Z and 0-9", () => {
+    const re = patternToRE("*");
+    ["c", "Ac", "cA", "0Ax", "x0A", "BA#", "#AB"].forEach((example) =>
+      isInvalidExample(re, example)
+    );
+  });
+
+  it("should not match substrings", () => {
+    const re = patternToRE("A*xC");
+    ["A1CZ", "AC1CZ", "ZA1C", "ZAC1C", "ZA1CZ", "ZAC1CZ"].forEach((example) =>
+      isInvalidExample(re, example)
+    );
+  });
+});
+
+describe("patternMatcher", () => {
+  const modulesList1 = [
+    "CS2100",
+    "GER1000",
+    "CS2040S",
+    "ST2131",
+    "MA1521",
+    "CS1231",
+    "CS2030",
+  ];
+
+  it("should match all modules with *", () => {
+    const matcher = patternMatcher("*");
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: [
+        "CS2100",
+        "GER1000",
+        "CS2040S",
+        "ST2131",
+        "MA1521",
+        "CS1231",
+        "CS2030",
+      ],
+      remaining: [],
+      infos: [],
+    });
+  });
+
+  it("should match only valid modules with pattern containing *", () => {
+    const matcher = patternMatcher("CS2*");
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: ["CS2100", "CS2040S", "CS2030"],
+      remaining: ["GER1000", "ST2131", "MA1521", "CS1231"],
+      infos: [],
+    });
+  });
+
+  it("should match only valid modules with pattern containing x", () => {
+    const matcher = patternMatcher("CS20xx");
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: ["CS2030"],
+      remaining: ["CS2100", "GER1000", "CS2040S", "ST2131", "MA1521", "CS1231"],
+      infos: [],
+    });
+  });
+
+  it("should match only valid modules with pattern containing x and *", () => {
+    const matcher = patternMatcher("CS20xx*");
+    evaluateMatcher(modulesList1, matcher).should.eql({
+      matched: ["CS2040S", "CS2030"],
+      remaining: ["CS2100", "GER1000", "ST2131", "MA1521", "CS1231"],
+      infos: [],
+    });
+  });
+});
+
+export { pattern };

--- a/src/matchRule/pattern/matchers.test.ts
+++ b/src/matchRule/pattern/matchers.test.ts
@@ -81,15 +81,17 @@ describe("patternMatcher", () => {
   it("should match all modules with *", () => {
     const matcher = patternMatcher("*");
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "pattern",
       matched: modulesList1,
       remaining: [],
-      infos: [],
+      results: [],
     });
   });
 
   it("should match only valid modules with pattern containing *", () => {
     const matcher = patternMatcher("CS2*");
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "pattern",
       matched: [
         ["CS2100", 4],
         ["CS2040S", 4],
@@ -101,13 +103,14 @@ describe("patternMatcher", () => {
         ["MA1521", 4],
         ["CS1231", 4],
       ],
-      infos: [],
+      results: [],
     });
   });
 
   it("should match only valid modules with pattern containing x", () => {
     const matcher = patternMatcher("CS20xx");
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "pattern",
       matched: [["CS2030", 4]],
       remaining: [
         ["CS2100", 4],
@@ -117,13 +120,14 @@ describe("patternMatcher", () => {
         ["MA1521", 4],
         ["CS1231", 4],
       ],
-      infos: [],
+      results: [],
     });
   });
 
   it("should match only valid modules with pattern containing x and *", () => {
     const matcher = patternMatcher("CS20xx*");
     evaluateMatcher(modulesList1, matcher).should.eql({
+      type: "pattern",
       matched: [
         ["CS2040S", 4],
         ["CS2030", 4],
@@ -135,7 +139,7 @@ describe("patternMatcher", () => {
         ["MA1521", 4],
         ["CS1231", 4],
       ],
-      infos: [],
+      results: [],
     });
   });
 });

--- a/src/matchRule/pattern/matchers.ts
+++ b/src/matchRule/pattern/matchers.ts
@@ -16,8 +16,8 @@ const patternToRE = (...patterns: Pattern[]): RegExp =>
 const patternMatcher = (pattern: Pattern): MatcherLeaf => {
   const re = patternToRE(pattern);
   return {
+    type: "pattern",
     match: ([moduleStr]: Module) => re.test.bind(re)(moduleStr),
-    infos: [],
   };
 };
 

--- a/src/matchRule/pattern/matchers.ts
+++ b/src/matchRule/pattern/matchers.ts
@@ -1,0 +1,24 @@
+import type { MatcherLeaf } from "../../matcher/types";
+import type { Module } from "../../module/types";
+import type { Pattern } from "./types";
+
+const patternToRE = (...patterns: Pattern[]): RegExp =>
+  new RegExp(
+    "^" +
+      patterns
+        .map((pattern) =>
+          pattern.replace(/x/g, "[0-9]").replace(/\*/g, "[A-Z0-9]*")
+        )
+        .join("|") +
+      "$"
+  );
+
+const patternMatcher = (pattern: Pattern): MatcherLeaf => {
+  const re = patternToRE(pattern);
+  return {
+    match: ([moduleStr]: Module) => re.test.bind(re)(moduleStr),
+    infos: [],
+  };
+};
+
+export { patternMatcher, patternToRE };

--- a/src/matchRule/pattern/matchers.ts
+++ b/src/matchRule/pattern/matchers.ts
@@ -17,6 +17,7 @@ const patternMatcher = (pattern: Pattern): MatcherLeaf => {
   const re = patternToRE(pattern);
   return {
     type: "pattern",
+    rule: pattern,
     match: ([moduleStr]: Module) => re.test.bind(re)(moduleStr),
   };
 };

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -7,13 +7,14 @@ const evaluateMatcher = (
   matcher: Matcher
 ): MatcherResult => {
   if (isMatcherLeaf(matcher)) {
-    const { type, match, info } = matcher;
+    const { type, rule, match, info } = matcher;
     const notMatch = (module: Module) => !match(module);
     const newMatched = remaining.filter(match);
     const newRemaining = remaining.filter(notMatch);
     return Object.assign(
       {
         type,
+        rule,
         matched: newMatched,
         remaining: newRemaining,
         results: [],
@@ -21,9 +22,10 @@ const evaluateMatcher = (
       newMatched.length > 0 && typeof info !== "undefined" ? { info } : {}
     );
   } else if (isMatcherBranch(matcher)) {
-    const { type, matchers, constraint } = matcher;
+    const { type, rule, matchers, constraint } = matcher;
     const matcherResult = {
       type,
+      rule,
       matched: [],
       remaining,
       results: [],
@@ -42,6 +44,7 @@ const evaluateMatcher = (
           [...accMatcheds, matched],
           {
             type,
+            rule,
             matched: [...accMatched, ...matched],
             remaining,
             results: [...accResults, result],

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -1,0 +1,55 @@
+import type { Module } from "../module/types";
+import type { Matcher, MatcherResult } from "./types";
+import { isMatcherBranch, isMatcherLeaf } from "./types";
+
+const evaluateMatcher = (
+  remaining: Module[],
+  matcher: Matcher
+): MatcherResult => {
+  if (isMatcherLeaf(matcher)) {
+    const { match, infos } = matcher;
+    const notMatch = (module: Module) => !match(module);
+    const newMatched = remaining.filter(match);
+    const newRemaining = remaining.filter(notMatch);
+    return {
+      matched: newMatched,
+      remaining: newRemaining,
+      infos: newMatched.length > 0 ? infos : [],
+    };
+  } else if (isMatcherBranch(matcher)) {
+    const { matchers, constraint } = matcher;
+    const matcherResult = {
+      matched: [],
+      remaining,
+      infos: [],
+    } as MatcherResult;
+    const [newMatcheds, newMatcherResult] = matchers.reduce(
+      (
+        [
+          accMatcheds,
+          { matched: accMatched, remaining: accRemaining, infos: accInfos },
+        ],
+        matcher
+      ) => {
+        const { matched, remaining, infos } = evaluateMatcher(
+          accRemaining,
+          matcher
+        );
+        return [
+          accMatcheds.concat([matched]),
+          {
+            matched: accMatched.concat(matched),
+            remaining,
+            infos: accInfos.concat(infos),
+          },
+        ];
+      },
+      [[] as Module[][], matcherResult]
+    );
+    return constraint(newMatcheds) ? newMatcherResult : matcherResult;
+  } else {
+    throw new Error("matcher is not well-defined");
+  }
+};
+
+export { evaluateMatcher };

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -1,13 +1,15 @@
 import type { Module } from "../module/types";
 
 type MatcherLeaf = {
+  type: string;
   match: (module: Module) => boolean;
-  infos: string[];
+  info?: string;
 };
 const isMatcherLeaf = (matcher: Matcher): matcher is MatcherLeaf =>
   "match" in matcher;
 
 type MatcherBranch = {
+  type: string;
   matchers: Matcher[];
   constraint: (matcheds: Module[][]) => boolean;
 };
@@ -17,9 +19,11 @@ const isMatcherBranch = (matcher: Matcher): matcher is MatcherBranch =>
 type Matcher = MatcherLeaf | MatcherBranch;
 
 type MatcherResult = {
+  type: string;
   matched: Module[];
   remaining: Module[];
-  infos: string[];
+  results: MatcherResult[];
+  info?: string;
 };
 
 export type { Matcher, MatcherBranch, MatcherLeaf, MatcherResult };

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -1,0 +1,26 @@
+import type { Module } from "../module/types";
+
+type MatcherLeaf = {
+  match: (module: Module) => boolean;
+  infos: string[];
+};
+const isMatcherLeaf = (matcher: Matcher): matcher is MatcherLeaf =>
+  "match" in matcher;
+
+type MatcherBranch = {
+  matchers: Matcher[];
+  constraint: (matcheds: Module[][]) => boolean;
+};
+const isMatcherBranch = (matcher: Matcher): matcher is MatcherBranch =>
+  "matchers" in matcher;
+
+type Matcher = MatcherLeaf | MatcherBranch;
+
+type MatcherResult = {
+  matched: Module[];
+  remaining: Module[];
+  infos: string[];
+};
+
+export type { Matcher, MatcherBranch, MatcherLeaf, MatcherResult };
+export { isMatcherBranch, isMatcherLeaf };

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -2,6 +2,7 @@ import type { Module } from "../module/types";
 
 type MatcherLeaf = {
   type: string;
+  rule: unknown;
   match: (module: Module) => boolean;
   info?: string;
 };
@@ -10,6 +11,7 @@ const isMatcherLeaf = (matcher: Matcher): matcher is MatcherLeaf =>
 
 type MatcherBranch = {
   type: string;
+  rule: unknown;
   matchers: Matcher[];
   constraint: (matcheds: Module[][]) => boolean;
 };
@@ -20,6 +22,7 @@ type Matcher = MatcherLeaf | MatcherBranch;
 
 type MatcherResult = {
   type: string;
+  rule: unknown;
   matched: Module[];
   remaining: Module[];
   results: MatcherResult[];

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -1,0 +1,3 @@
+type Module = [string, number];
+
+export type { Module };

--- a/src/satisfier/index.ts
+++ b/src/satisfier/index.ts
@@ -1,0 +1,64 @@
+import type { Module } from "../module/types";
+import type { Satisfier, SatisfierResult } from "./types";
+import { isSatisfierBranch, isSatisfierLeaf } from "./types";
+
+const evaluateSatisfier = (
+  assigned: Module[],
+  satisfier: Satisfier
+): SatisfierResult => {
+  if (isSatisfierLeaf(satisfier)) {
+    const { constraint, infos, messages } = satisfier;
+    const satisfied = constraint(assigned);
+    return satisfied
+      ? {
+          assigned,
+          satisfied,
+          infos,
+          messages: [],
+        }
+      : {
+          assigned,
+          satisfied,
+          infos: [],
+          messages,
+        };
+  } else if (isSatisfierBranch(satisfier)) {
+    const { filter, satisfiers, constraint } = satisfier;
+    const newAssigned = filter(assigned);
+    const satisfierResult: SatisfierResult = {
+      assigned: newAssigned,
+      satisfied: true,
+      infos: [],
+      messages: [],
+    };
+
+    const [newSatisfieds, newSatisfierResult] = satisfiers.reduce(
+      ([accSatisfieds, satisfierResult], satisfier) => {
+        const { infos: accInfos, messages: accMessages } = satisfierResult;
+        const { satisfied, infos, messages } = evaluateSatisfier(
+          newAssigned,
+          satisfier
+        );
+        return [
+          [...accSatisfieds, satisfied],
+          {
+            assigned: newAssigned,
+            satisfied,
+            infos: accInfos.concat(infos),
+            messages: accMessages.concat(messages),
+          },
+        ];
+      },
+      [[] as boolean[], satisfierResult]
+    );
+
+    const satisfied = constraint(newSatisfieds);
+    return satisfied
+      ? { ...newSatisfierResult, satisfied, messages: [] }
+      : { ...newSatisfierResult, assigned, satisfied, infos: [] };
+  } else {
+    throw new Error("satisfier is not well-defined");
+  }
+};
+
+export { evaluateSatisfier };

--- a/src/satisfier/types.ts
+++ b/src/satisfier/types.ts
@@ -1,16 +1,19 @@
 import type { Module } from "../module/types";
 
 type SatisfierLeaf = {
+  type: string;
+  rule: unknown;
   constraint: (assigned: Module[]) => boolean;
-  infos: string[];
-  messages: string[];
+  info?: string;
 };
 const isSatisfierLeaf = (satisfier: Satisfier): satisfier is SatisfierLeaf =>
   !("satisfiers" in satisfier);
 
 type SatisfierBranch = {
-  satisfiers: Satisfier[];
+  type: string;
+  rule: unknown;
   filter: (assigned: Module[]) => Module[];
+  satisfiers: Satisfier[];
   constraint: (satisfieds: boolean[]) => boolean;
 };
 const isSatisfierBranch = (
@@ -20,10 +23,12 @@ const isSatisfierBranch = (
 type Satisfier = SatisfierLeaf | SatisfierBranch;
 
 type SatisfierResult = {
+  type: string;
+  rule: unknown;
   assigned: Module[];
   satisfied: boolean;
-  infos: string[];
-  messages: string[];
+  results: SatisfierResult[];
+  info?: string;
 };
 
 export type { Satisfier, SatisfierBranch, SatisfierLeaf, SatisfierResult };

--- a/src/satisfier/types.ts
+++ b/src/satisfier/types.ts
@@ -1,0 +1,30 @@
+import type { Module } from "../module/types";
+
+type SatisfierLeaf = {
+  constraint: (assigned: Module[]) => boolean;
+  infos: string[];
+  messages: string[];
+};
+const isSatisfierLeaf = (satisfier: Satisfier): satisfier is SatisfierLeaf =>
+  !("satisfiers" in satisfier);
+
+type SatisfierBranch = {
+  satisfiers: Satisfier[];
+  filter: (assigned: Module[]) => Module[];
+  constraint: (satisfieds: boolean[]) => boolean;
+};
+const isSatisfierBranch = (
+  satisfier: Satisfier
+): satisfier is SatisfierBranch => "satisfiers" in satisfier;
+
+type Satisfier = SatisfierLeaf | SatisfierBranch;
+
+type SatisfierResult = {
+  assigned: Module[];
+  satisfied: boolean;
+  infos: string[];
+  messages: string[];
+};
+
+export type { Satisfier, SatisfierBranch, SatisfierLeaf, SatisfierResult };
+export { isSatisfierBranch, isSatisfierLeaf };

--- a/src/satisfyRule/inequality/index.ts
+++ b/src/satisfyRule/inequality/index.ts
@@ -1,0 +1,18 @@
+import type { Inequality } from "./types";
+import { InequalitySign } from "./types";
+
+const parseInequality = (inequality: Inequality): [InequalitySign, number] => {
+  const matches = inequality.match(/^[<>]=(\d+)$/);
+  if (matches === null || matches.length === 0) {
+    throw new Error("inequality is malformed");
+  }
+  const n = parseInt(matches[1]);
+  return [
+    inequality.startsWith("<=")
+      ? InequalitySign.AtMost
+      : InequalitySign.AtLeast,
+    n,
+  ];
+};
+
+export { parseInequality };

--- a/src/satisfyRule/inequality/satisfiers.test.ts
+++ b/src/satisfyRule/inequality/satisfiers.test.ts
@@ -20,60 +20,60 @@ describe("inequalitySatisfier", () => {
   it("should satisfy upper bound of MCs if total MC count is equal", () => {
     const satisfier1 = inequalitySatisfier("<=28");
     evaluateSatisfier(modulesList1, satisfier1).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: true,
-      infos: [],
-      messages: [],
+      assigned: modulesList1,
+      results: [],
     });
   });
 
   it("should satisfy upper bound of MCs if total MC count is lower", () => {
     const satisfier2 = inequalitySatisfier("<=32");
     evaluateSatisfier(modulesList1, satisfier2).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: true,
-      infos: [],
-      messages: [],
+      assigned: modulesList1,
+      results: [],
     });
   });
 
   it("should not satisfy upper bound of MCs if total MC count is higher", () => {
     const satisfier = inequalitySatisfier("<=16");
     evaluateSatisfier(modulesList1, satisfier).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: false,
-      infos: [],
-      messages: ["modules exceed the maximum MC requirement of 16"],
+      assigned: modulesList1,
+      results: [],
     });
   });
 
   it("should satisfy lower bound of MCs if total MC count is higher", () => {
     const satisfier = inequalitySatisfier(">=16");
     evaluateSatisfier(modulesList1, satisfier).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: true,
-      infos: [],
-      messages: [],
+      assigned: modulesList1,
+      results: [],
     });
   });
 
   it("should satisfy lower bound of MCs if total MC count is equal", () => {
     const satisfier = inequalitySatisfier(">=28");
     evaluateSatisfier(modulesList1, satisfier).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: true,
-      infos: [],
-      messages: [],
+      assigned: modulesList1,
+      results: [],
     });
   });
 
   it("should not satisfy lower bound of MCs if total MC count is lower", () => {
     const satisfier = inequalitySatisfier(">=40");
     evaluateSatisfier(modulesList1, satisfier).should.eql({
-      assigned: modulesList1,
+      type: "inequality",
       satisfied: false,
-      infos: [],
-      messages: ["modules do not meet minimum MC requirement of 40"],
+      assigned: modulesList1,
+      results: [],
     });
   });
 });

--- a/src/satisfyRule/inequality/satisfiers.test.ts
+++ b/src/satisfyRule/inequality/satisfiers.test.ts
@@ -1,0 +1,79 @@
+import chai from "chai";
+
+import { evaluateSatisfier } from "../../satisfier";
+import type { Module } from "../../module/types";
+import { inequalitySatisfier } from "./satisfiers";
+
+chai.should();
+
+describe("inequalitySatisfier", () => {
+  const modulesList1 = [
+    ["CS2100", 4],
+    ["GER1000", 4],
+    ["CS2040S", 4],
+    ["ST2131", 4],
+    ["MA1521", 4],
+    ["CS1231", 4],
+    ["CS2030", 4],
+  ] as Module[];
+
+  it("should satisfy upper bound of MCs if total MC count is equal", () => {
+    const satisfier1 = inequalitySatisfier("<=28");
+    evaluateSatisfier(modulesList1, satisfier1).should.eql({
+      assigned: modulesList1,
+      satisfied: true,
+      infos: [],
+      messages: [],
+    });
+  });
+
+  it("should satisfy upper bound of MCs if total MC count is lower", () => {
+    const satisfier2 = inequalitySatisfier("<=32");
+    evaluateSatisfier(modulesList1, satisfier2).should.eql({
+      assigned: modulesList1,
+      satisfied: true,
+      infos: [],
+      messages: [],
+    });
+  });
+
+  it("should not satisfy upper bound of MCs if total MC count is higher", () => {
+    const satisfier = inequalitySatisfier("<=16");
+    evaluateSatisfier(modulesList1, satisfier).should.eql({
+      assigned: modulesList1,
+      satisfied: false,
+      infos: [],
+      messages: ["modules exceed the maximum MC requirement of 16"],
+    });
+  });
+
+  it("should satisfy lower bound of MCs if total MC count is higher", () => {
+    const satisfier = inequalitySatisfier(">=16");
+    evaluateSatisfier(modulesList1, satisfier).should.eql({
+      assigned: modulesList1,
+      satisfied: true,
+      infos: [],
+      messages: [],
+    });
+  });
+
+  it("should satisfy lower bound of MCs if total MC count is equal", () => {
+    const satisfier = inequalitySatisfier(">=28");
+    evaluateSatisfier(modulesList1, satisfier).should.eql({
+      assigned: modulesList1,
+      satisfied: true,
+      infos: [],
+      messages: [],
+    });
+  });
+
+  it("should not satisfy lower bound of MCs if total MC count is lower", () => {
+    const satisfier = inequalitySatisfier(">=40");
+    evaluateSatisfier(modulesList1, satisfier).should.eql({
+      assigned: modulesList1,
+      satisfied: false,
+      infos: [],
+      messages: ["modules do not meet minimum MC requirement of 40"],
+    });
+  });
+});

--- a/src/satisfyRule/inequality/satisfiers.ts
+++ b/src/satisfyRule/inequality/satisfiers.ts
@@ -1,0 +1,25 @@
+import type { Module } from "../../module/types";
+import type { SatisfierLeaf } from "../../satisfier/types";
+import { parseInequality } from "./";
+import type { Inequality } from "./types";
+import { InequalitySign } from "./types";
+
+const calculateTotalMCs = (assigned: Module[]) =>
+  assigned.map(([, mc]) => mc).reduce((x, y) => x + y);
+
+const inequalitySatisfier = (inequality: Inequality): SatisfierLeaf => {
+  const [sign, n] = parseInequality(inequality);
+  return sign === InequalitySign.AtLeast
+    ? {
+        constraint: (assigned) => calculateTotalMCs(assigned) >= n,
+        infos: [],
+        messages: [`modules do not meet minimum MC requirement of ${n}`],
+      }
+    : {
+        constraint: (assigned) => calculateTotalMCs(assigned) <= n,
+        infos: [],
+        messages: [`modules exceed the maximum MC requirement of ${n}`],
+      };
+};
+
+export { inequalitySatisfier };

--- a/src/satisfyRule/inequality/satisfiers.ts
+++ b/src/satisfyRule/inequality/satisfiers.ts
@@ -5,21 +5,18 @@ import type { Inequality } from "./types";
 import { InequalitySign } from "./types";
 
 const calculateTotalMCs = (assigned: Module[]) =>
-  assigned.map(([, mc]) => mc).reduce((x, y) => x + y);
+  assigned.map(([, mc]) => mc).reduce((x, y) => x + y, 0);
 
 const inequalitySatisfier = (inequality: Inequality): SatisfierLeaf => {
   const [sign, n] = parseInequality(inequality);
-  return sign === InequalitySign.AtLeast
-    ? {
-        constraint: (assigned) => calculateTotalMCs(assigned) >= n,
-        infos: [],
-        messages: [`modules do not meet minimum MC requirement of ${n}`],
-      }
-    : {
-        constraint: (assigned) => calculateTotalMCs(assigned) <= n,
-        infos: [],
-        messages: [`modules exceed the maximum MC requirement of ${n}`],
-      };
+  return {
+    type: "inequality",
+    rule: inequality,
+    constraint: (assigned) =>
+      sign === InequalitySign.AtLeast
+        ? calculateTotalMCs(assigned) >= n
+        : calculateTotalMCs(assigned) <= n,
+  };
 };
 
 export { inequalitySatisfier };

--- a/src/satisfyRule/inequality/types.ts
+++ b/src/satisfyRule/inequality/types.ts
@@ -1,3 +1,9 @@
 type Inequality = string;
 
+const enum InequalitySign {
+  AtLeast,
+  AtMost,
+}
+
 export type { Inequality };
+export { InequalitySign };

--- a/src/satisfyRule/satisfiers.ts
+++ b/src/satisfyRule/satisfiers.ts
@@ -1,0 +1,63 @@
+import { blockSatisfier } from "../block/satisfiers";
+import { Directory } from "../directory";
+import type {
+  Satisfier,
+  SatisfierBranch,
+  SatisfierLeaf,
+} from "../satisfier/types";
+import type { Some } from "../some/types";
+import { inequalitySatisfier } from "./inequality/satisfiers";
+import type {
+  AndSatisfyRule,
+  MCSatisfyRule,
+  OrSatisfyRule,
+  SatisfyRule,
+} from "./types";
+
+const MCSatisfyRuleSatisfier = ({ mc }: MCSatisfyRule): SatisfierLeaf =>
+  inequalitySatisfier(mc);
+
+const andSatisfyRuleSatisfier = (
+  dir: Directory,
+  { and }: AndSatisfyRule
+): SatisfierBranch => ({
+  filter: (assigned) => assigned,
+  satisfiers: and.map((rule) => satisfyRuleSatisfier(dir, rule)),
+  constraint: (satisfieds) => satisfieds.every((bool) => bool),
+});
+
+const orSatisfyRuleSatisfier = (
+  dir: Directory,
+  { or }: OrSatisfyRule
+): SatisfierBranch => ({
+  filter: (assigned) => assigned,
+  satisfiers: or.map((rule) => satisfyRuleSatisfier(dir, rule)),
+  constraint: (satisfieds) => satisfieds.some((bool) => bool),
+});
+
+// TODO: Implement subblock resolution
+const satisfyRuleSatisfier = (
+  dir: Directory,
+  satisfy: Some<SatisfyRule>
+): Satisfier => {
+  if (Array.isArray(satisfy)) {
+    return satisfyRuleSatisfier(dir, { and: satisfy });
+  } else if (typeof satisfy === "string") {
+    return blockSatisfier(dir, dir.find(satisfy));
+  } else if ("mc" in satisfy) {
+    return MCSatisfyRuleSatisfier(satisfy);
+  } else if ("and" in satisfy) {
+    return andSatisfyRuleSatisfier(dir, satisfy);
+  } else if ("or" in satisfy) {
+    return orSatisfyRuleSatisfier(dir, satisfy);
+  } else {
+    throw new Error("satisfy rule(s) is (are) not well-defined");
+  }
+};
+
+export {
+  MCSatisfyRuleSatisfier,
+  andSatisfyRuleSatisfier,
+  orSatisfyRuleSatisfier,
+  satisfyRuleSatisfier,
+};


### PR DESCRIPTION
The general idea is that a matcher provides instructions on how to perform matching of modules (in a tree layout), and `evaluateMatcher` performs the matching.

A matching is done by taking a list of unassigned modules (named `remaining` in the code) and then matching as many modules as possible, applying rules from the first to the last, lastly returning a `MatcherResult` (with properties `matched`, `remaining` and `infos`).
1. The first type of matcher, `MatcherLeaf`, has a `match` function which filters out individual modules and an `info` property which can provide a single information string.
2. The second type of matcher, `MatcherBranch`, seeks to combine multiple matchers together with a `matchers` property, an array of submatchers, and a `constraint` function that examines how its submatchers have matched modules and enforces a constraint (e.g. all submatchers must have matched >= 1 module). If this constraint is not met, the matcher will not modify the existing matching.